### PR TITLE
Remove FTOC, skip vertex conversions

### DIFF
--- a/src/ActorMultiTexture.cpp
+++ b/src/ActorMultiTexture.cpp
@@ -120,10 +120,10 @@ void ActorMultiTexture::DrawPrimitives()
 	v[2].t = RageVector2( pTexCoordRect->right, pTexCoordRect->bottom );	// bottom right
 	v[3].t = RageVector2( pTexCoordRect->right, pTexCoordRect->top );	// top right
 
-	v[0].c = m_pTempState->diffuse[0];	// top left
-	v[1].c = m_pTempState->diffuse[2];	// bottom left
-	v[2].c = m_pTempState->diffuse[3];	// bottom right
-	v[3].c = m_pTempState->diffuse[1];	// top right
+	v[0].c = RageVColor(m_pTempState->diffuse[0]);	// top left
+	v[1].c = RageVColor(m_pTempState->diffuse[2]);	// bottom left
+	v[2].c = RageVColor(m_pTempState->diffuse[3]);	// bottom right
+	v[3].c = RageVColor(m_pTempState->diffuse[1]);	// top right
 
 	DISPLAY->DrawQuad( v );
 

--- a/src/ActorMultiVertex.cpp
+++ b/src/ActorMultiVertex.cpp
@@ -207,7 +207,7 @@ void ActorMultiVertex::SetVertexPos( int index, float x, float y, float z )
 
 void ActorMultiVertex::SetVertexColor( int index, RageColor c )
 {
-	AMV_DestTweenState().vertices[index].c = c;
+	AMV_DestTweenState().vertices[index].c = RageVColor(c);
 }
 
 void ActorMultiVertex::SetVertexCoords( int index, float TexCoordX, float TexCoordY )
@@ -237,22 +237,13 @@ void ActorMultiVertex::DrawPrimitives()
 
 		for( size_t i=0; i < TS.vertices.size(); i++ )
 		{
-			// RageVColor uses a uint8_t for each channel.  0-255.
-			// RageColor uses a float. 0-1.
-			// So each channel of the RageVColor needs to be converted to a float,
-			// multiplied by the channel from the RageColor, then the result
-			// converted to uint8_t.  If implicit conversion is allowed to happen,
-			// sometimes the compiler decides to turn the RageColor into a uint8_t,
-			// which makes any value other than 1 into 0.  Thus, the explicit
-			// conversions.  -Kyz
-#define MULT_COLOR_ELEMENTS(color_a, color_b) \
-	color_a= static_cast<uint8_t>(static_cast<float>(color_a) * color_b);
-			// RageVColor * RageColor
-			MULT_COLOR_ELEMENTS(TS.vertices[i].c.b, m_pTempState->diffuse[0].b);
-			MULT_COLOR_ELEMENTS(TS.vertices[i].c.r, m_pTempState->diffuse[0].r);
-			MULT_COLOR_ELEMENTS(TS.vertices[i].c.g, m_pTempState->diffuse[0].g);
-			MULT_COLOR_ELEMENTS(TS.vertices[i].c.a, m_pTempState->diffuse[0].a);
-#undef MULT_COLOR_ELEMENTS
+			/* TODO: This shouldn't be done on the RageVColor directly,
+			 * the math should be done on RageColor. I'm not here to
+			 * refactor this block right now, so it will remain -Colby */
+			TS.vertices[i].c.b *= m_pTempState->diffuse[0].b;
+			TS.vertices[i].c.r *= m_pTempState->diffuse[0].r;
+			TS.vertices[i].c.g *= m_pTempState->diffuse[0].g;
+			TS.vertices[i].c.a *= m_pTempState->diffuse[0].a;
 		}
 	
 	}
@@ -270,7 +261,7 @@ void ActorMultiVertex::DrawPrimitives()
 
 		for( size_t i=0; i < TS.vertices.size(); i++ )
 		{
-			TS.vertices[i].c = m_pTempState->glow;
+			TS.vertices[i].c = RageVColor(m_pTempState->glow);
 		}		
 		DISPLAY->SetTextureMode( TextureUnit_1, TextureMode_Glow );
 		DrawInternal( AMV_TempState );

--- a/src/BitmapText.cpp
+++ b/src/BitmapText.cpp
@@ -688,7 +688,7 @@ void BitmapText::DrawPrimitives()
 			RageColor c = m_ShadowColor;
 			c.a *= m_pTempState->diffuse[0].a;
 			for( unsigned i=0; i<m_aVertices.size(); i++ )
-				m_aVertices[i].c = c;
+				m_aVertices[i].c = RageVColor(c);
 			DrawChars( false );
 
 			DISPLAY->PopMatrix();
@@ -700,7 +700,7 @@ void BitmapText::DrawPrimitives()
 		{
 			stroke_color.a *= m_pTempState->diffuse[0].a;
 			for( unsigned i=0; i<m_aVertices.size(); i++ )
-				m_aVertices[i].c = stroke_color;
+				m_aVertices[i].c = RageVColor(stroke_color);
 			DrawChars( true );
 		}
 
@@ -712,7 +712,7 @@ void BitmapText::DrawPrimitives()
 			{
 				const RageColor color = RAINBOW_COLORS[color_index];
 				for( unsigned j=i; j<i+4; j++ )
-					m_aVertices[j].c = color;
+					m_aVertices[j].c = RageVColor(color);
 
 				color_index = (color_index+1) % RAINBOW_COLORS.size();
 			}
@@ -728,10 +728,10 @@ void BitmapText::DrawPrimitives()
 				iEnd = min( iEnd, m_aVertices.size() );
 				for( ; i < iEnd; i += 4 )
 				{
-					m_aVertices[i+0].c = m_pTempState->diffuse[0];	// top left
-					m_aVertices[i+1].c = m_pTempState->diffuse[2];	// bottom left
-					m_aVertices[i+2].c = m_pTempState->diffuse[3];	// bottom right
-					m_aVertices[i+3].c = m_pTempState->diffuse[1];	// top right
+					m_aVertices[i+0].c = RageVColor(m_pTempState->diffuse[0]);	// top left
+					m_aVertices[i+1].c = RageVColor(m_pTempState->diffuse[2]);	// bottom left
+					m_aVertices[i+2].c = RageVColor(m_pTempState->diffuse[3]);	// bottom right
+					m_aVertices[i+3].c = RageVColor(m_pTempState->diffuse[1]);	// top right
 				}
 				if( iter == m_mAttributes.end() )
 					break;
@@ -754,10 +754,10 @@ void BitmapText::DrawPrimitives()
 				}
 				for( ; i < iEnd; i += 4 )
 				{
-					m_aVertices[i+0].c = temp_attr_diffuse[0];	// top left
-					m_aVertices[i+1].c = temp_attr_diffuse[2];	// bottom left
-					m_aVertices[i+2].c = temp_attr_diffuse[3];	// bottom right
-					m_aVertices[i+3].c = temp_attr_diffuse[1];	// top right
+					m_aVertices[i+0].c = RageVColor(temp_attr_diffuse[0]);	// top left
+					m_aVertices[i+1].c = RageVColor(temp_attr_diffuse[2]);	// bottom left
+					m_aVertices[i+2].c = RageVColor(temp_attr_diffuse[3]);	// bottom right
+					m_aVertices[i+3].c = RageVColor(temp_attr_diffuse[1]);	// top right
 				}
 			}
 		}
@@ -812,7 +812,7 @@ void BitmapText::DrawPrimitives()
 			size_t iEnd = iter == m_mAttributes.end()? m_aVertices.size():iter->first*4;
 			iEnd = min( iEnd, m_aVertices.size() );
 			for( ; i < iEnd; ++i )
-				m_aVertices[i].c = m_pTempState->glow;
+				m_aVertices[i].c = RageVColor(m_pTempState->glow);
 			if( iter == m_mAttributes.end() )
 				break;
 			// Set the glow according to this attribute.
@@ -827,11 +827,11 @@ void BitmapText::DrawPrimitives()
 			{
 				if( m_internalGlow.a > 0 )
 				{
-					m_aVertices[i].c = attr.glow * m_internalGlow;
+					m_aVertices[i].c = RageVColor(attr.glow * m_internalGlow);
 				}
 				else
 				{
-					m_aVertices[i].c = attr.glow;
+					m_aVertices[i].c = RageVColor(attr.glow);
 				}
 			}
 		}

--- a/src/GraphDisplay.cpp
+++ b/src/GraphDisplay.cpp
@@ -32,9 +32,9 @@ public:
 		Actor::SetTextureRenderStates();
 
 		for( unsigned i = 0; i < m_Quads.size(); ++i )
-			m_Quads[i].c = this->m_pTempState->diffuse[0];
+			m_Quads[i].c = RageVColor(this->m_pTempState->diffuse[0]);
 		for( unsigned i = 0; i < m_pCircles.size(); ++i )
-			m_pCircles[i].c = this->m_pTempState->diffuse[0];
+			m_pCircles[i].c = RageVColor(this->m_pTempState->diffuse[0]);
 
 		DISPLAY->DrawQuads( &m_Quads[0], m_Quads.size() );
 
@@ -118,7 +118,7 @@ public:
 
 		for( int i = 0; i < 2*VALUE_RESOLUTION; ++i )
 		{
-			m_Slices[i].c = RageColor(1,1,1,1);
+			m_Slices[i].c = RageVColor(RageColor(1, 1, 1, 1));
 			m_Slices[i].t = RageVector2( 0,0 );
 		}
 	}
@@ -265,7 +265,7 @@ void GraphDisplay::UpdateVerts()
 		m_pGraphBody->m_Slices[i*2+1].t = RageVector2( fU, pRect->bottom );
 
 		LineStrip[i].p = RageVector3( fX, fY, 0 );
-		LineStrip[i].c = RageColor( 1,1,1,1 );
+		LineStrip[i].c = RageVColor(RageColor( 1, 1, 1, 1 ));
 		LineStrip[i].t = RageVector2( 0,0 );
 	}
 

--- a/src/GrooveRadar.cpp
+++ b/src/GrooveRadar.cpp
@@ -161,8 +161,8 @@ void GrooveRadar::GrooveRadarValueMap::DrawPrimitives()
 	v[0].p = RageVector3( 0, 0, 0 );
 	RageColor midcolor = color;
 	midcolor.a = RADAR_CENTER_ALPHA;
-	v[0].c = midcolor;
-	v[1].c = color;
+	v[0].c = RageVColor(midcolor);
+	v[1].c = RageVColor(color);
 
 	for( int i=0; i<NUM_SHOWN_RADAR_CATEGORIES+1; i++ ) // do one extra to close the fan
 	{
@@ -190,7 +190,7 @@ void GrooveRadar::GrooveRadarValueMap::DrawPrimitives()
 		const float fY = -RageFastSin(fRotation) * fDistFromCenter;
 
 		v[i].p = RageVector3( fX, fY, 0 );
-		v[i].c = this->m_pTempState->diffuse[0];
+		v[i].c = RageVColor(this->m_pTempState->diffuse[0]);
 	}
 
 	// TODO: Add this back in -Chris

--- a/src/NoteDisplay.cpp
+++ b/src/NoteDisplay.cpp
@@ -1006,9 +1006,9 @@ void NoteDisplay::DrawHoldPart(vector<Sprite*> &vpSpr,
 		if(fAlpha > 0)
 			bAllAreTransparent = false;
 
-		queue.v[0].p = left_vert;  queue.v[0].c = color; queue.v[0].t = RageVector2(fTexCoordLeft,  fTexCoordTop);
-		queue.v[1].p = center_vert; queue.v[1].c = color; queue.v[1].t = RageVector2(fTexCoordCenter, fTexCoordTop);
-		queue.v[2].p = right_vert;  queue.v[2].c = color; queue.v[2].t = RageVector2(fTexCoordRight, fTexCoordTop);
+		queue.v[0].p = left_vert;  queue.v[0].c = RageVColor(color); queue.v[0].t = RageVector2(fTexCoordLeft,  fTexCoordTop);
+		queue.v[1].p = center_vert; queue.v[1].c = RageVColor(color); queue.v[1].t = RageVector2(fTexCoordCenter, fTexCoordTop);
+		queue.v[2].p = right_vert;  queue.v[2].c = RageVColor(color); queue.v[2].t = RageVector2(fTexCoordRight, fTexCoordTop);
 		queue.v+=3;
 
 		if(queue.Free() < 3 || last_vert_set)

--- a/src/RageDisplay_OGL.cpp
+++ b/src/RageDisplay_OGL.cpp
@@ -953,8 +953,7 @@ ActualVideoModeParams RageDisplay_Legacy::GetActualVideoModeParams() const
 
 static void SetupVertices( const RageSpriteVertex v[], int iNumVerts )
 {
-	static float *Vertex, *Texture, *Normal;	
-	static GLubyte *Color;
+	static float *Vertex, *Texture, *Normal, *Color;
 	static int Size = 0;
 	if (iNumVerts > Size)
 	{
@@ -964,7 +963,7 @@ static void SetupVertices( const RageSpriteVertex v[], int iNumVerts )
 		delete [] Texture;
 		delete [] Normal;
 		Vertex = new float[Size*3];
-		Color = new GLubyte[Size*4];
+		Color = new float[Size*4];
 		Texture = new float[Size*2];
 		Normal = new float[Size*3];
 	}
@@ -988,7 +987,7 @@ static void SetupVertices( const RageSpriteVertex v[], int iNumVerts )
 	glVertexPointer( 3, GL_FLOAT, 0, Vertex );
 
 	glEnableClientState( GL_COLOR_ARRAY );
-	glColorPointer( 4, GL_UNSIGNED_BYTE, 0, Color );
+	glColorPointer( 4, GL_FLOAT, 0, Color );
 
 	glEnableClientState( GL_TEXTURE_COORD_ARRAY );
 	glTexCoordPointer( 2, GL_FLOAT, 0, Texture );

--- a/src/ScreenNetSelectBase.cpp
+++ b/src/ScreenNetSelectBase.cpp
@@ -608,7 +608,7 @@ void ColorBitmapText::DrawPrimitives( )
 			RageColor c = m_ShadowColor;
 			c.a *= m_pTempState->diffuse[0].a;
 			for( unsigned i=0; i<m_aVertices.size(); i++ )
-				m_aVertices[i].c = c;
+				m_aVertices[i].c = RageVColor(c);
 			DrawChars( true );
 
 			DISPLAY->PopMatrix();
@@ -630,7 +630,7 @@ void ColorBitmapText::DrawPrimitives( )
 				}
 			}
 			for( unsigned j=0; j<4; j++ )
-				m_aVertices[i+j].c = c;
+				m_aVertices[i+j].c = RageVColor(c);
 		}
 
 		DrawChars( false );
@@ -642,7 +642,7 @@ void ColorBitmapText::DrawPrimitives( )
 		DISPLAY->SetTextureMode( TextureUnit_1, TextureMode_Glow );
 
 		for( unsigned i=0; i<m_aVertices.size(); i++ )
-			m_aVertices[i].c = m_pTempState->glow;
+			m_aVertices[i].c = RageVColor(m_pTempState->glow);
 		DrawChars( false );
 	}
 }

--- a/src/Sprite.cpp
+++ b/src/Sprite.cpp
@@ -639,16 +639,16 @@ void Sprite::DrawTexture( const TweenState *state )
 			DISPLAY->TranslateWorld( m_fShadowLengthX, m_fShadowLengthY, 0 );	// shift by 5 units
 			RageColor c = m_ShadowColor;
 			c.a *= state->diffuse[0].a;
-			v[0].c = v[1].c = v[2].c = v[3].c = c;	// semi-transparent black
+			v[0].c = v[1].c = v[2].c = v[3].c = RageVColor(c);	// semi-transparent black
 			DISPLAY->DrawQuad( v );
 			DISPLAY->PopMatrix();
 		}
 
 		// render the diffuse pass
-		v[0].c = state->diffuse[0]; // top left
-		v[1].c = state->diffuse[2]; // bottom left
-		v[2].c = state->diffuse[3]; // bottom right
-		v[3].c = state->diffuse[1]; // top right
+		v[0].c = RageVColor(state->diffuse[0]); // top left
+		v[1].c = RageVColor(state->diffuse[2]); // bottom left
+		v[2].c = RageVColor(state->diffuse[3]); // bottom right
+		v[3].c = RageVColor(state->diffuse[1]); // top right
 		DISPLAY->DrawQuad( v );
 	}
 
@@ -656,7 +656,7 @@ void Sprite::DrawTexture( const TweenState *state )
 	if( state->glow.a > 0.0001f )
 	{
 		DISPLAY->SetTextureMode( TextureUnit_1, TextureMode_Glow );
-		v[0].c = v[1].c = v[2].c = v[3].c = state->glow;
+		v[0].c = v[1].c = v[2].c = v[3].c = RageVColor(state->glow);
 		DISPLAY->DrawQuad( v );
 	}
 	DISPLAY->SetEffectMode( EffectMode_Normal );


### PR DESCRIPTION
This skips a lot of useless cpu work. Pushing to a branch because
this breaks D3D and I can't test/fix that right now.

This gets gameplay running 60fps fairly consistently on my RPi 4.